### PR TITLE
Fix fps mismatch

### DIFF
--- a/pruebasVideoPython.py
+++ b/pruebasVideoPython.py
@@ -26,6 +26,7 @@ font_path = "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf"
 line_spacing = 4
 margin_x, margin_y = 50, 50
 duracion_por_frame = 0.03 # Define the duration per frame here
+fps_salida = int(1 / duracion_por_frame)
 
 # Colores específicos para highlighting (using the updated scheme)
 number_color = (128, 128, 128) # Gris para los números de línea
@@ -271,7 +272,7 @@ for i in range(int(4.5 / duracion_por_frame)): # 4.5 second pause
 # 4. Create video
 clips = [ImageClip(f).set_duration(duracion_por_frame) for f in frames]
 video = concatenate_videoclips(clips, method="compose")
-video.write_videofile(output_video, fps=24)
+video.write_videofile(output_video, fps=fps_salida)
 
 # Cleanup
 shutil.rmtree("frames")


### PR DESCRIPTION
## Summary
- compute output video fps from `duracion_por_frame`
- use computed fps when writing the video

## Testing
- `python -m py_compile pruebasVideoPython.py`

------
https://chatgpt.com/codex/tasks/task_e_6857aa6d291c832dab29e53da63ad8c7